### PR TITLE
feat(ci): add build and deploy workflow for Distributed Press

### DIFF
--- a/.github/workflows/deploy-distributed-press.yaml
+++ b/.github/workflows/deploy-distributed-press.yaml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Check out the repository
+      - uses: actions/checkout@v3
+
+      # Step 2: Set up Node.js
+      - name: Set up Node.js 18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # Step 3: Install dependencies and build the site
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build the site
+        run: npm run build
+
+      # Step 4: Deploy to Distributed Press
+      - name: Publish to Distributed Press
+        uses: hyphacoop/actions-distributed-press@v1.1.0
+        with:
+          publish_dir: public
+          dp_url: https://api.distributed.press
+          refresh_token: ${{ secrets.DISTRIBUTED_PRESS_TOKEN }}
+          site_url: getdweb.net
+          deploy_http: true
+          deploy_hyper: true
+          deploy_ipfs: true
+
+      # Step 6: Deploy to GitHub Pages
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: public
+          publish_branch: prod


### PR DESCRIPTION
This adds a CI workflow that builds the Gatsby site and deploys it to Distributed Press (`ipns://`, `hyper://`, `http://`) and GitHub Pages (`prod` branch) on every push to` main`.

Note:
If you prefer to keep the HTTP version hosted via Fleek, we can remove the HTTP deploy from GitHub Actions; otherwise, to use GitHub Pages for HTTP, the `prod` branch will serve as the published output.

## DP Token:
After getting the free DP token, add a var `DISTRIBUTED_PRESS_TOKEN` in secrets and variables in the repo.

## Domain setup:
### CNAME
Type | Name | Value
-- | -- | --
CNAME | `getdweb.net` | `api.distributed.press.`

### DNSLink Delegation (NS Record)
Type | Name | Value
-- | -- | --
NS | `_dnslink.getdweb.net` | `api.distributed.press.`

> Ensure that the trailing dot `.` is included in api.distributed.press. as required.

### Additional:
GitHub pages domain setup: https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site